### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{css,sass,scss}]
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.{html,tpl}]
+indent_style = space
+indent_size = 2
+
+[*.php]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
To make sure everyone use the right config, we'll use a `.editorconfig`.
Go to http://editorconfig.org to see if your editor supports it, otherwise install the required plugin. :)

[PrestaShop recently moved to PSR-2](http://build.prestashop.com/news/prestashop-moves-to-psr-2/) but we still use tabs to indent HTML and javascript.

2 spaces for js, html and css (sass of course) became pretty standard over the past few years.

This is still open for discussion, so please give us your opinion.
