### PR TITLE
[+] FO : Add Grunt task for copying files from module

### DIFF
--- a/_dev/Gruntfile.js
+++ b/_dev/Gruntfile.js
@@ -1,0 +1,29 @@
+module.exports = function(grunt) {
+  	grunt.loadNpmTasks('grunt-contrib-copy');
+
+    grunt.registerTask('import', 'Import files from module', function() {
+        var module = grunt.option('module');
+        var path = grunt.option('theme') ? grunt.option('theme') : '..';
+
+        if (typeof module === 'undefined') {
+            grunt.log.error('Module name is required!');
+            return false;
+        }
+
+        grunt.config('copy', {
+            main: {
+                files: [
+                  {
+                      expand: true,
+                      cwd: '../../' + path + '/modules/',
+                      src: [module + '/**/*.tpl'],
+                      dest: '../modules'
+                  },
+                ],
+            },
+        });
+        grunt.task.run('copy');
+    });
+
+    grunt.registerTask('default', ['import']);
+};

--- a/_dev/package.json
+++ b/_dev/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "grunt-contrib-copy": "^1.0.0",
     "stylus": "^0.52.4",
     "webpack": "^1.12.2"
   }


### PR DESCRIPTION
This is simple task for copying all *.TPL files from module folder.
#### Install

`cd _dev`
`npm install`
`npm install -g grunt-cli`
#### Usage

`grunt import --module=MODULE_NAME`
or
`grunt import --module=MODULE_NAME --theme=THEME_NAME`
#### Example

`grunt import --module=blockcart`
