### PR TITLE
npm run watch don't update dev.css file

### DIFF
--- a/_dev/package.json
+++ b/_dev/package.json
@@ -4,7 +4,7 @@
   "description": "Tools to help while developing the starter theme",
   "main": "index.js",
   "scripts": {
-    "watch": "stylus --watch",
+    "watch": "stylus --watch --sourcemap --include-css css/dev.styl -o ../assets/css",
     "build": "stylus --compress --sourcemap --include-css css/dev.styl -o ../assets/css",
     "watch-build": "stylus --watch --compress --sourcemap --include-css css/dev.styl -o ../assets/css"
   },


### PR DESCRIPTION
Hi, 
when I run command `npm run --watch`, stylus don't change file assets/css/dev.css
in file package.json the watch command is incomplete?
It's correct to change it from `"watch": "stylus --watch"`, to `"watch": "stylus --watch --sourcemap --include-css css/dev.styl -o ../assets/css",`?
thanks in advance
