### PR TITLE
[-] FO : Fix hook location for AEU

### DIFF
--- a/templates/catalog/_partials/product-prices.tpl
+++ b/templates/catalog/_partials/product-prices.tpl
@@ -3,8 +3,8 @@
     {block name='product_discount'}
       {if $product.has_discount}
         <p class="product-discount">
-          <span class="regular-price">{$product.regular_price}</span>
           {hook h='displayProductPriceBlock' product=$product type="old_price"}
+          <span class="regular-price">{$product.regular_price}</span>
         </p>
       {/if}
     {/block}


### PR DESCRIPTION
## Description

When you use Advanced EU Compliance, it adds the label "Before" when you have a promo on a product and the label was misplaced. For example, it indicated "25€ before" instead of "Before 25€".
## Steps to Test this Fix

Install the Advanced EU Compliance module and check the price display on the product page when a product has a promo.
## Forge Ticket (optional)

http://forge.prestashop.com/browse/BOOM-475
