### PR TITLE
// Fix hook called twice

### DIFF
--- a/templates/checkout/cart.tpl
+++ b/templates/checkout/cart.tpl
@@ -16,7 +16,7 @@
     {/block}
 
     <div>
-      {hook h='displayShoppingCart'}
+      {hook h='displayShoppingCartFooter'}
     </div>
 
     {block name='cart_summary'}


### PR DESCRIPTION
The hook displayShoppingCart was called twice and displayShoppingCartFooter was forgotten
