### PR TITLE
Add a hook on cart product line

### DIFF
--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -50,4 +50,6 @@
   {l s='Remove' mod="blockcart"}
 </a>
 
+{hook h='displayCartExtraProductActions' product=$product}
+
 <span class="product-price">{$product.total}</span>


### PR DESCRIPTION
This PR adds a new hook called `displayCartExtraProductActions` on cart product line
