### PR TITLE
Use SQL server from another Docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,13 @@ before_install:
   - sudo dpkg -i google-chrome*.deb
 
 before_script:
-  - docker run -e PS_INSTALL_AUTO=0 -e PS_FOLDER_ADMIN=admin-dev -e PS_FOLDER_INSTALL=install-dev -p 80:80 -tid --name=prestashop -v $TRAVIS_BUILD_DIR:/var/www/html/themes/StarterTheme  prestashop/prestashop-git:$PHP_VERSION
+  - docker run --name mysql -e MYSQL_ROOT_PASSWORD=admin -d mysql:5.6
+  - docker run -e DB_SERVER=mysql -e PS_INSTALL_AUTO=0 -e PS_FOLDER_ADMIN=admin-dev -e PS_FOLDER_INSTALL=install-dev -p 80:80 -tid  --link mysql --name=prestashop -v $TRAVIS_BUILD_DIR:/var/www/html/themes/StarterTheme  prestashop/prestashop-git:$PHP_VERSION
   - docker exec prestashop rm -Rf themes/classic
   - cp config/theme.dist.yml config/theme.yml
   - docker cp travis-scripts/parameters.yml.travis prestashop:/var/www/html/app/config/parameters.yml
   - bash travis-scripts/wait-for-sql.sh
-  - docker exec prestashop php install-dev/index_cli.php --db_create=1 --db_password=admin --name=prestashop.unit.test --password=123456789
+  - docker exec prestashop php install-dev/index_cli.php --db_create=1 --db_server=mysql --db_password=admin --name=prestashop.unit.test --password=123456789
   - docker cp prestashop:/var/www/html/tests/Selenium selenium
   - cp travis-scripts/settings.travis.js selenium/settings.js
   - cd selenium && npm install

--- a/travis-scripts/parameters.yml.travis
+++ b/travis-scripts/parameters.yml.travis
@@ -1,6 +1,6 @@
 # This file is a used by travis install with specific setting.
 parameters:
-    database_host:     localhost
+    database_host:     mysql
     database_port:     ~
     database_name:     prestashop
     database_user:     root

--- a/travis-scripts/wait-for-sql.sh
+++ b/travis-scripts/wait-for-sql.sh
@@ -4,6 +4,6 @@ RET=1
 while [ $RET -ne 0 ]; do
     echo "\n* Waiting for confirmation of MySQL service startup"
     sleep 5
-    docker exec -ti prestashop mysql -padmin -e "status" > /dev/null 2>&1
+    docker exec -ti prestashop mysql -padmin -h mysql -e "status" > /dev/null 2>&1
     RET=$?
 done


### PR DESCRIPTION
This change will allow later:
- to change the SQL engine or its version easily
- to reduce the size of the image [PrestaShop-git on Docker Hub](https://hub.docker.com/r/prestashop/prestashop-git/) and make its builds faster
