### PR TITLE
Restore ps_creation_date in parameters.yml

### DIFF
--- a/templates/customer/history.tpl
+++ b/templates/customer/history.tpl
@@ -36,8 +36,8 @@
               </span>
             </td>
             <td>
-              {if $order.details.invoice_ur}
-                <a href="{$order.details.invoice_ur}" class="order-invoice-link">{l s='PDF'}</a>
+              {if $order.details.invoice_url}
+                <a href="{$order.details.invoice_url}" class="order-invoice-link">{l s='PDF'}</a>
               {else}
                 -
               {/if}

--- a/travis-scripts/parameters.yml.travis
+++ b/travis-scripts/parameters.yml.travis
@@ -19,5 +19,6 @@ parameters:
     secret:            ThisTokenIsNotSoSecretChangeIt
     ps_caching: CacheMemcache
     ps_cache_enable: true
+    ps_creation_date: ~
     cookie_key: ThisTokenIsNotSoSecretChangeIt
     cookie_iv: ThisTokenIsNotSoSecretChangeIt


### PR DESCRIPTION
This PR will remove notices while installing PrestaShop.
