### PR TITLE
FO: Fix wrong template total variables reference in checkout pages

### DIFF
--- a/templates/checkout/_partials/cart-detailed-totals.tpl
+++ b/templates/checkout/_partials/cart-detailed-totals.tpl
@@ -9,7 +9,7 @@
   </div>
 
   <div class="cart-total">
-    <span class="label">{$cart.totals.total.label}</span>
-    <span class="value">{$cart.totals.total.amount}</span>
+    <span class="label">{$cart.total.label}</span>
+    <span class="value">{$cart.total.amount}</span>
   </div>
 </div>

--- a/templates/checkout/_partials/cart-summary-items-subtotal.tpl
+++ b/templates/checkout/_partials/cart-summary-items-subtotal.tpl
@@ -1,4 +1,4 @@
 <div id="items-subtotal">
   <span>{$cart.summary_string}</span>
-  <span>{$cart.totals.total.amount}</span>
+  <span>{$cart.total.amount}</span>
 </div>

--- a/templates/checkout/_partials/cart-summary-totals.tpl
+++ b/templates/checkout/_partials/cart-summary-totals.tpl
@@ -12,8 +12,8 @@
 
   {block name='cart_summary_totals'}
     <div class="cart-summary-totals">
-      <span class="label">{$cart.totals.total.label}</span>
-      <span class="value">{$cart.totals.total.value}</span>
+      <span class="label">{$cart.total.label}</span>
+      <span class="value">{$cart.total.value}</span>
     </div>
   {/block}
 </div>


### PR DESCRIPTION
In `$cart.totals.total`, `totals` member is undefined.
