### PR TITLE
Display a warning to explain why the order button is disabled

### DIFF
--- a/templates/checkout/_partials/steps/payment.tpl
+++ b/templates/checkout/_partials/steps/payment.tpl
@@ -95,6 +95,20 @@
       <button type="submit" {if !$selected_payment_option} disabled {/if}>
         {l s='Order with an obligation to pay' d='Shop.Theme.Actions'}
       </button>
+      {if $show_final_summary}
+        <article class="notification notification-danger s-alert-payment-condtions" role="alert" data-alert="danger">
+          {l
+            s='Please make sure you\'ve chosen a [1]payment method[/1] and accepted the [2]terms and conditions[/2].'
+            sprintf=[
+            '[1]' => '<a href="#checkout-payment-step">',
+            '[/1]' => '</a>',
+            '[2]' => '<a href="#conditions-to-approve">',
+            '[/2]' => '</a>'
+            ]
+            d='Shop.Theme.Checkout'
+          }
+        </article>
+      {/if}
     </div>
     <div class="ps-hidden-by-js">
       {if $selected_payment_option and $all_conditions_approved}


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | Display a warning to explain why the order button is disabled when you have the final summary option enabled. |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1099 |

Same as https://github.com/PrestaShop/PrestaShop/pull/5898
