### PR TITLE
Apply naming convention for javascript class

### DIFF
--- a/templates/checkout/_partials/cart-detailed.tpl
+++ b/templates/checkout/_partials/cart-detailed.tpl
@@ -1,4 +1,4 @@
-<div class="cart-overview -js-cart" data-refresh-url="{$urls.pages.cart}?ajax=1">
+<div class="cart-overview js-cart" data-refresh-url="{$urls.pages.cart}?ajax=1">
   <div class="body">
     <ul>
       {foreach from=$cart.products item=product}

--- a/templates/checkout/_partials/cart-summary.tpl
+++ b/templates/checkout/_partials/cart-summary.tpl
@@ -1,4 +1,4 @@
-<section id="checkout-cart-summary" class="-js-cart js-checkout-summary" data-refresh-url="{$urls.pages.cart}?ajax=1">
+<section id="checkout-cart-summary" class="js-cart js-checkout-summary" data-refresh-url="{$urls.pages.cart}?ajax=1">
   {hook h='displayCheckoutSummaryTop'}
   {block name='cart_summary_header'}
     <header>


### PR DESCRIPTION
Replace `-js-cart` with `js-cart` in cart templates.
