### PR TITLE
Prevent display of payment return if empty

### DIFF
--- a/templates/checkout/order-confirmation.tpl
+++ b/templates/checkout/order-confirmation.tpl
@@ -5,9 +5,11 @@
 {/block}
 
 {block name='page_content_container' prepend}
+  {if ! empty($HOOK_PAYMENT_RETURN)}
   <section id="content-hook_payment_return">
     {$HOOK_PAYMENT_RETURN nofilter}
   </section>
+  {/if}
 
   <section id="content-hook_order_confirmation">
     <h3>{l s='Your order is confirmed' d='Shop.Theme.Checkout'}</h3>


### PR DESCRIPTION
It should prevent display of payment return block if empty

See also https://github.com/PrestaShop/PrestaShop/pull/6066
