### PR TITLE
Add productExtraContent data to the product page

### DIFF
--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -209,6 +209,11 @@
               </section>
             {/if}
           {/block}
+          {foreach from=$product.extraContent item=extra key=extraKey}
+            <div class="{$extra.attr}" id="extra-{$extraKey}">
+              {$extra.content nofilter}
+            </div>
+          {/foreach}
         {/block}
       </section>
     {/block}


### PR DESCRIPTION
This PR is a backport of https://github.com/PrestaShop/PrestaShop/pull/6216

On this theme, we do not have tabs. We display all the module data one after another.
