### PR TITLE
Fixed bug in the link tracking number for the detail order 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - docker
 
 addons:
-    chrome: stable
     apt:
         packages:
         - postfix

--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -141,7 +141,7 @@
               <td>{$line.carrier_name}</td>
               <td>{$line.shipping_weight}</td>
               <td>{$line.shipping_cost}</td>
-              <td>{$line.tracking}</td>
+              <td>{$line.tracking nofilter}</td>
             </tr>
           {/foreach}
         </tbody>


### PR DESCRIPTION
See: https://github.com/PrestaShop/PrestaShop/pull/8207