### PR TITLE
Fix product pack miniature path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - docker
 
 addons:
-    chrome: stable
     apt:
         packages:
         - postfix

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -50,7 +50,9 @@
 
             <span class="regular-price">{$product.regular_price}</span>
             {if $product.discount_type === 'percentage'}
-              <span class="discount-percentage">{$product.discount_percentage}</span>
+              <span class="discount-percentage discount-product">{$product.discount_percentage}</span>
+            {elseif $product.discount_type === 'amount'}
+              <span class="discount-amount discount-product">{$product.discount_amount_to_display}</span>
             {/if}
           {/if}
 

--- a/templates/catalog/_partials/product-prices.tpl
+++ b/templates/catalog/_partials/product-prices.tpl
@@ -82,5 +82,9 @@
 
     {hook h='displayProductPriceBlock' product=$product type="weight" hook_origin='product_sheet'}
     {hook h='displayProductPriceBlock' product=$product type="after_price"}
+
+    {if $product.delivery_information}
+      <span class="delivery-information">{$product.delivery_information}</span>
+    {/if}
   </div>
 {/if}

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -197,7 +197,7 @@
                 <h3>{l s='Pack content' d='Shop.Theme.Catalog'}</h3>
                 {foreach from=$packItems item="product_pack"}
                   {block name='product_pack_miniature'}
-                    {include file='catalog/_partials/pack-product.tpl' product=$product_pack}
+                    {include file='catalog/_partials/miniatures/pack-product.tpl' product=$product_pack}
                   {/block}
                 {/foreach}
               </section>

--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -141,7 +141,7 @@
               <td>{$line.carrier_name}</td>
               <td>{$line.shipping_weight}</td>
               <td>{$line.shipping_cost}</td>
-              <td>{$line.tracking}</td>
+              <td>{$line.tracking nofilter}</td>
             </tr>
           {/foreach}
         </tbody>


### PR DESCRIPTION
Starter theme has a wrong include path for pack product miniature.
Was 'catalog/_partials/pack-product.tpl' but should be 'catalog/_partials/miniatures/pack-product.tpl'