### PR TITLE
Add composer install in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
   - docker exec prestashop git fetch origin
   - docker exec prestashop git checkout .
   - docker exec prestashop git checkout $TRAVIS_BRANCH
+  - docker exec prestashop composer install
   - docker exec prestashop rm -Rf themes/classic
   - cp config/theme.dist.yml config/theme.yml
   - docker cp travis-scripts/parameters.yml.travis prestashop:/var/www/html/app/config/parameters.yml


### PR DESCRIPTION
Fixes dependencies for previous branches of PrestaShop

Another merge was necessary: https://github.com/PrestaShop/docker-ci/pull/11
Waiting for builds in https://hub.docker.com/r/prestashop/prestashop-git/builds/ to be done.