### PR TITLE
FO: fix input to persist carrier choice in context

### DIFF
--- a/templates/checkout/_partials/steps/shipping.tpl
+++ b/templates/checkout/_partials/steps/shipping.tpl
@@ -42,7 +42,7 @@
             {foreach from=$delivery_options item=carrier key=carrier_id}
               <div>
                 <div class="delivery-option">
-                  <input type="radio" name="delivery_option[{$id_address}]" id="delivery_option_{$carrier.id}" value="{$carrier_id}"{if $delivery_option == $carrier_id} checked{/if}>
+                  <input type="radio" name="delivery_option[{$id_address}]" id="delivery_option_{$carrier.id}" value="{$carrier_id},"{if $delivery_option == $carrier_id} checked{/if}>
                   <label for="delivery_option_{$carrier.id}">
                     <span>{$carrier.label}</span>
                     {if $carrier.logo}


### PR DESCRIPTION
The delivery option input value needs a trailing comma for Cart::setDeliveryOption to work and update the id_carrier in context->cart as expected. The comma is needed because of Cart::getDeliveryOptionList strange behavior (adding a comma in its array keys ) and because Cart::getIdCarrierFromDeliveryOption relies on the result of that function