### PR TITLE
Use h2 for product list

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -12,7 +12,7 @@
     {/block}
 
     {block name='product_name'}
-      <h1 class="h2" itemprop="name"><a href="{$product.url}">{$product.name}</a></h1>
+      <h2 class="h2" itemprop="name"><a href="{$product.url}">{$product.name}</a></h2>
     {/block}
 
     {block name='product_description_short'}


### PR DESCRIPTION
I think it's better to use h2 for product list. We can't have many h1 in pages and often, we have many products. It's SEO and W3C valid.