### PR TITLE
No need to precise type attribute in script

### DIFF
--- a/templates/_partials/javascript.tpl
+++ b/templates/_partials/javascript.tpl
@@ -23,17 +23,17 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 {foreach $javascript.external as $js}
-  <script type="text/javascript" src="{$js.uri}" {$js.attribute}></script>
+  <script src="{$js.uri}" {$js.attribute}></script>
 {/foreach}
 
 {foreach $javascript.inline as $js}
-  <script type="text/javascript">
+  <script>
     {$js.content nofilter}
   </script>
 {/foreach}
 
 {if isset($vars) && $vars|@count}
-  <script type="text/javascript">
+  <script>
     {foreach from=$vars key=var_name item=var_value}
     var {$var_name} = {$var_value|json_encode nofilter};
     {/foreach}


### PR DESCRIPTION
Default type attribute for script tag is "text/javascript", so no need to declare it in HTML.