### PR TITLE
Check if $notifications is defined

### DIFF
--- a/templates/_partials/notifications.tpl
+++ b/templates/_partials/notifications.tpl
@@ -22,6 +22,8 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
+
+{if isset($notifications)}
 <aside id="notifications">
 
   {if $notifications.error}
@@ -73,3 +75,4 @@
   {/if}
 
 </aside>
+{/if}


### PR DESCRIPTION
Like in classic theme, we need to verify ```$notifications``` defined in notifications template. It cause a bug on reset password page.